### PR TITLE
torchcodec fix

### DIFF
--- a/install.js
+++ b/install.js
@@ -1,4 +1,7 @@
 module.exports = {
+  requires: {
+    bundle: "ai"
+  },
   run: [
     {
       method: "shell.run",

--- a/install.js
+++ b/install.js
@@ -28,7 +28,8 @@ module.exports = {
         venv: "env",                // Edit this to customize the venv folder path
         path: "app",                // Edit this to customize the path to start the shell from
         message: [
-          "uv pip install -e ."
+          "uv pip install -e .",
+          "uv pip install transformers==4.50.3"
         ]
       }
     }

--- a/install.js
+++ b/install.js
@@ -26,7 +26,14 @@ module.exports = {
         path: "app",
         message: [
           "uv pip install -e .",
+          "uv pip install hf_xet"
         ]
+      }
+    },
+    {
+      method: "notify",
+      params: {
+        html: "Click the 'start' tab to get started!"
       }
     }
   ]

--- a/install.js
+++ b/install.js
@@ -1,6 +1,5 @@
 module.exports = {
   run: [
-    // Edit this step to customize the git repository to use
     {
       method: "shell.run",
       params: {
@@ -9,27 +8,24 @@ module.exports = {
         ]
       }
     },
-    // Delete this step if your project does not use torch
     {
       method: "script.start",
       params: {
         uri: "torch.js",
         params: {
-          venv: "env",                // Edit this to customize the venv folder path
-          path: "app",                // Edit this to customize the path to start the shell from
-          // xformers: true   // uncomment this line if your project requires xformers
+          venv: "env",
+          path: "app",
+          // xformers: true
         }
       }
     },
-    // Edit this step with your custom install commands
     {
       method: "shell.run",
       params: {
-        venv: "env",                // Edit this to customize the venv folder path
-        path: "app",                // Edit this to customize the path to start the shell from
+        venv: "env",
+        path: "app",
         message: [
           "uv pip install -e .",
-          "uv pip install transformers==4.50.3"
         ]
       }
     }

--- a/install.js
+++ b/install.js
@@ -29,6 +29,7 @@ module.exports = {
         path: "app",
         message: [
           "uv pip install -e .",
+          "uv pip uninstall torchcodec",
           "uv pip install hf_xet"
         ]
       }

--- a/start.js
+++ b/start.js
@@ -4,33 +4,24 @@ module.exports = {
     {
       method: "shell.run",
       params: {
-        venv: "env",                // Edit this to customize the venv folder path
+        venv: "env",
         env: {
           "PYTORCH_ENABLE_MPS_FALLBACK": 1,
           "HF_HUB_ENABLE_HF_TRANSFER": 0
-        },                   // Edit this to customize environment variables (see documentation)
-        path: "app",                // Edit this to customize the path to start the shell from
+        },
+        path: "app",
         message: [
           "f5-tts_infer-gradio"
         ],
         on: [{
-          // The regular expression pattern to monitor.
-          // When this pattern occurs in the shell terminal, the shell will return,
-          // and the script will go onto the next step.
-          "event": "/http:\/\/\\S+/",   
-
-          // "done": true will move to the next step while keeping the shell alive.
-          // "kill": true will move to the next step after killing the shell.
+          "event": "/http:\/\/\\S+/",
           "done": true
         }]
       }
     },
     {
-      // This step sets the local variable 'url'.
-      // This local variable will be used in pinokio.js to display the "Open WebUI" tab when the value is set.
       method: "local.set",
       params: {
-        // the input.event is the regular expression match object from the previous step
         url: "{{input.event[0]}}"
       }
     }

--- a/torch.js
+++ b/torch.js
@@ -1,18 +1,5 @@
 module.exports = {
   run: [
-    // nvidia 50 series
-    {
-      "when": "{{gpu === 'nvidia' && kernel.gpu_model && / 50.+/.test(kernel.gpu_model) }}",
-      "method": "shell.run",
-      "params": {
-        "venv": "{{args && args.venv ? args.venv : null}}",
-        "path": "{{args && args.path ? args.path : '.'}}",
-        "message": [
-          "uv pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu128"
-        ]
-      },
-      "next": null
-    },
     // windows nvidia
     {
       "when": "{{platform === 'win32' && gpu === 'nvidia'}}",
@@ -20,7 +7,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1 {{args && args.xformers ? 'xformers' : ''}}  --index-url https://download.pytorch.org/whl/cu121"
+        "message": "uv pip install torch==2.7.0 torchvision==0.22.0 torchaudio==2.7.0 {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu128 --force-reinstall --no-deps"
       }
     },
     // windows amd
@@ -70,7 +57,7 @@ module.exports = {
       "params": {
         "venv": "{{args && args.venv ? args.venv : null}}",
         "path": "{{args && args.path ? args.path : '.'}}",
-        "message": "uv pip install torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1 {{args && args.xformers ? 'xformers' : ''}}  --index-url https://download.pytorch.org/whl/cu121"
+        "message": "uv pip install torch==2.7.0 torchvision==0.22.0 torchaudio==2.7.0 {{args && args.xformers ? 'xformers' : ''}} --index-url https://download.pytorch.org/whl/cu128 --force-reinstall --no-deps"
       }
     },
     // linux rocm (amd)


### PR DESCRIPTION
**Background:** torchaudio 2.9.0 requires torchcodec which is why f5-tts installs torchcodec.
This fails during runtime with a "could not load libtorchcodec" error.

**Related issue:** https://github.com/meta-pytorch/torchcodec/issues/912

The easiest solution is to downgrade torch / torchaudio to 2.7.0 which doesn't require torchcodec and uninstalling torchcodec.

- pin torch 2.7.0
- uninstall torchcodec
- use hf-xet
- add bundle ai
- remove comments