### PR TITLE
Fix broken installs/updates: re-pin torch stack and transformers

### DIFF
--- a/install.js
+++ b/install.js
@@ -30,7 +30,10 @@ module.exports = {
         message: [
           "uv pip install -e .",
           "uv pip uninstall torchcodec",
-          "uv pip install hf_xet"
+          // transformers >= 5 requires torch.float8_e8m0fnu (torch >= 2.7) at import
+          // time and breaks the torch 2.4.1 platforms (directml/cpu/mac) with
+          // "AttributeError: module 'torch' has no attribute 'float8_e8m0fnu'"
+          "uv pip install hf_xet transformers==4.50.3"
         ]
       }
     },

--- a/pinokio.json
+++ b/pinokio.json
@@ -1,0 +1,7 @@
+{
+  "title": "e2-f5-tts",
+  "description": "F5-TTS: A Fairytaler that Fakes Fluent and Faithful Speech with Flow Matching https://huggingface.co/spaces/mrfakename/E2-F5-TTS",
+  "plugin": {
+    "menu": []
+  }
+}

--- a/update.js
+++ b/update.js
@@ -18,7 +18,11 @@ module.exports = {
       message: [
         "uv pip install -e .",
         "uv pip uninstall torchcodec",
-        "uv pip install hf_xet"
+        "uv pip install hf_xet",
+        // transformers >= 5 requires torch.float8_e8m0fnu (torch >= 2.7) at import
+        // time and breaks the torch 2.4.1 platforms (directml/cpu/mac) with
+        // "AttributeError: module 'torch' has no attribute 'float8_e8m0fnu'"
+        "uv pip install transformers==4.50.3"
       ]
     }
   }, {

--- a/update.js
+++ b/update.js
@@ -16,8 +16,23 @@ module.exports = {
       venv: "env",                // Edit this to customize the venv folder path
       path: "app",                // Edit this to customize the path to start the shell from
       message: [
-        "pip install -e ."
+        "uv pip install -e .",
+        "uv pip uninstall torchcodec",
+        "uv pip install hf_xet"
       ]
+    }
+  }, {
+    // Re-run torch.js AFTER the editable install:
+    // "uv pip install -e ." can upgrade torch/torchaudio to versions that
+    // mismatch each other (and torch-directml), breaking the venv with
+    // "OSError: [WinError 127]". This step pins them back per platform/gpu.
+    method: "script.start",
+    params: {
+      uri: "torch.js",
+      params: {
+        venv: "env",
+        path: "app"
+      }
     }
   }, {
     method: "fs.link",


### PR DESCRIPTION
## Problem

**1. Update breaks the venv (WinError 127)**

Running **Update** can break the venv with:

```
OSError: [WinError 127] Die angegebene Prozedur wurde nicht gefunden
```

when torchaudio tries to load its native extension (`_torchaudio.pyd`).

**Root cause:** `update.js` runs `pip install -e .` after pulling the app, and F5-TTS''s dependency resolution can upgrade torch/torchaudio to versions that mismatch each other and the platform pins from `torch.js`. Observed on a Windows AMD (DirectML) install:

| package | after update | required |
|---|---|---|
| torch | 2.12.0 | 2.4.1 (hard requirement of torch-directml) |
| torchaudio | 2.11.0 | 2.4.1 (must match torch) |
| torchvision | 0.19.1 | 0.19.1 |
| torch-directml | 0.2.5.dev240914 | — |

The update also reinstalls `torchcodec`, which `install.js` deliberately removes.

**2. transformers >= 5 breaks torch 2.4.1 platforms (fresh installs too)**

transformers >= 5 references `torch.float8_e8m0fnu` at import time (`transformers/integrations/finegrained_fp8.py`), which only exists in torch >= 2.7. On the torch 2.4.1 platforms (Windows DirectML/CPU, Mac, Linux CPU/ROCm) this breaks `from transformers import pipeline` with:

```
AttributeError: module ''torch'' has no attribute ''float8_e8m0fnu''
ModuleNotFoundError: Could not import module ''pipeline''.
```

## Fix

- `update.js`: mirror the `install.js` post-install commands (`uv pip install -e .`, `uv pip uninstall torchcodec`, `uv pip install hf_xet`) and re-run `torch.js` **after** the editable install (same `script.start` pattern as `install.js`), so the platform/gpu-correct torch stack is re-pinned on every update
- `install.js` + `update.js`: re-pin `transformers==4.50.3` — the same version this repo pinned before (1ceb4cd), verified working with torch 2.4.1 + DirectML
- Add a basic `pinokio.json` metadata file (title/description), which the repo was missing

Verified on the affected machine: re-running the torch.js install command restored `torch==2.4.1+cpu` / `torchaudio==2.4.1` / `torch_directml.is_available() == True`, the WinError 127 is gone, and TTS inference works with transformers 4.50.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)